### PR TITLE
Remove unnecessary channel check

### DIFF
--- a/src/main/java/tk/coaster3000/worldinfo/WorldInfoPlugin.java
+++ b/src/main/java/tk/coaster3000/worldinfo/WorldInfoPlugin.java
@@ -192,13 +192,6 @@ public class WorldInfoPlugin extends JavaPlugin implements PluginMessageListener
 			}
 		}
 		
-		// Warn if message received on a non-existent channel
-		if (!match) {
-			if (informPlayer) {
-				player.sendMessage("Message Recieved but was not the same channel.");
-			}
-			return;
-		}
 		try {
 			if (informPlayer) {
 				player.sendMessage("Message recieved and sending data on channel " + channel);

--- a/src/main/java/tk/coaster3000/worldinfo/WorldInfoPlugin.java
+++ b/src/main/java/tk/coaster3000/worldinfo/WorldInfoPlugin.java
@@ -184,14 +184,6 @@ public class WorldInfoPlugin extends JavaPlugin implements PluginMessageListener
 	public void onPluginMessageReceived(String channel, Player player,
 	                                    byte[] bytes) {
 		log.info("Message received from " + player.getName());
-
-		boolean match = false;
-		for(String ch : channels) {
-			if (channel.equals(ch)) {
-				match = true;
-			}
-		}
-		
 		try {
 			if (informPlayer) {
 				player.sendMessage("Message recieved and sending data on channel " + channel);


### PR DESCRIPTION
Correct me if I'm wrong, but this should literally never happen, as the plugin shouldn't be able to hear messages on channels it hasn't registered as listening on.
