### PR TITLE
Add a third channel for clients who need it

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,7 @@
 plugin-channels:
   - world_id
   - world_info
+  - world_identifier
 inform-player: false
 encoding: UTF-8
 mode: UUID


### PR DESCRIPTION
I've had some reports that my mod [World Border Viewer](https://github.com/waffle-stomper/WorldBorderViewer) is conflicting with VoxelMap, since they both use the 'world_id' channel. Most of the time VoxelMap falls back to the 'world_info' channel, but under certain conditions it doesn't work.

I've avoided using the 'world_info' channel, since JourneyMap registers it exclusively and doesn't try to fall back to 'world_id'. 

This PR adds a third channel, ('world_identifier'), to avoid stepping on their toes, but I kept the name vague in case other mods want to use it, (assuming the user isn't running WorldBorderViewer).
