### PR TITLE
Fixed character encoding bug with different OS's

### DIFF
--- a/src/main/java/co/civcraft/worldinfo/WorldInfoPlugin.java
+++ b/src/main/java/co/civcraft/worldinfo/WorldInfoPlugin.java
@@ -196,7 +196,8 @@ public class WorldInfoPlugin extends JavaPlugin implements PluginMessageListener
 			ID_MODE mode = idMode;
 			if(bytes.length != 0) {
 				try {
-					mode = ID_MODE.valueOf(new String(bytes));
+					//Dont forget to specify your character set boys and girls
+					mode = ID_MODE.valueOf(new String(bytes,encoding));
 				} catch (IllegalArgumentException e) {
 					mode = idMode;
 				}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,6 +2,7 @@ plugin-channels:
   - world_id
   - world_info
   - world_identifier
+  - world_name
 inform-player: false
 encoding: UTF-8
 mode: UUID

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: ${name}
 description: ${description}
 author: Chris (Coaster3000 | Coaster4321)
-authors: [ProgrammerDan, PatchyKnowly]
+authors: [ProgrammerDan, PatchyKnowly, Mr_Little_Kitty]
 website: ${url}
 version: ${version}
 main: ${groupId}.${name}Plugin


### PR DESCRIPTION
Fixed the bug that would stop anyone from being able to get the world name from the server.

Because the character set from the config file was not being used, the bytes received by the server were being decoded against the servers default character set. In the case of Civcraft, the default character set was ISO_8859_1. This causes the problem because all client-side mod developers were being told to send their bytes encoded with UTF-8.

This is now fixed and mod developers will finally be able to see the name of the shard instead of the disgusting UUID :)
